### PR TITLE
Fix xlrd iter / getiterator issue

### DIFF
--- a/bpaingest/libs/excel_wrapper.py
+++ b/bpaingest/libs/excel_wrapper.py
@@ -30,6 +30,10 @@ field_definition_default = FieldDefinition(
     "<replace>", "<replace>", None, False, None, False
 )
 
+# prevent xlrd from using defusedxml
+# https://stackoverflow.com/a/65131301
+xlrd.xlsx.ensure_elementtree_imported(False, None)
+xlrd.xlsx.Element_has_iter = True
 
 def make_field_definition(attribute, column_name, **kwargs):
     return field_definition_default._replace(


### PR DESCRIPTION
dev-requirements in bpaotu has recently added jupyter for a nicer development experience, which installs defusedxml

Apparently when this is present, xlrd uses it instead of xml.etree and this causes issues with the ingest w
https://github.com/python-excel/xlrd/commit/886093dbe831f0b5e639333d027d09d5d901b91e

for elem in self.tree.iter() if Element_has_iter else self.tree.getiterator():

AttributeError: 'ElementTree' object has no attribute 'getiterator'

This is a temporary solution. Ideas:
- use a different Excel parsing library in bpa-ingest
- convert the context_metadata file to .xls rather than .xlsx (xlrd dropped support for xlsx)
- still use this fix in bpa-ingest if it causes no issues elsewhere
- don't use jupyter in bpaotu